### PR TITLE
attempt to support hiding search, timeline and fstab devices

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -9,8 +9,14 @@
         <entry name="showHidden" type="bool">
             <default>false</default>
         </entry>
-        <entry name="showDevices" type="bool">
+        <entry name="showTimeline" type="bool">
             <default>true</default>
+        </entry>
+        <entry name="showSearch" type="bool">
+            <default>true</default>
+        </entry>
+        <entry name="showDevices" type="int">
+            <default>0</default>
         </entry>
         <entry name="widgetWidth" type="int">
             <default>250</default>

--- a/package/contents/ui/FullRepresentation.qml
+++ b/package/contents/ui/FullRepresentation.qml
@@ -41,36 +41,94 @@ Item {
     }
 
     PlasmaCore.SortFilterModel {
-        id: placesHiddenFilterModel
+        id: placesNoHidden
         sourceModel: placesSource.models.places
         filterRole: 'hidden'
         filterRegExp: 'false'
     }
-
-    PlasmaCore.SortFilterModel {
-        id: placesDeviceFilterModel
-        sourceModel: placesSource.models.places
-        filterRole: 'isDevice'
-        filterRegExp: 'false'
-    }
-
-    PlasmaCore.SortFilterModel {
-        id: placesHiddenDevicesFilterModel
-        sourceModel: placesHiddenFilterModel
-        filterRole: 'isDevice'
-        filterRegExp: 'false'
-    }
-
-    property var currentModel: {
-        if (!showHidden && !showDevices) {
-            return placesHiddenDevicesFilterModel
-        } else if (!showHidden) {
-            return placesHiddenFilterModel
-        } else if (!showDevices) {
-            return placesDeviceFilterModel
-        } else {
+    
+    property var placesMaybeHidden {
+        if (showHidden) {
             return placesSource.models.places
+        } else {
+            return placesNoHidden
         }
+    }
+
+    PlasmaCore.SortFilterModel {
+        id: placesNoTimeline
+        sourceModel: placesMaybeHidden
+        filterRole: 'url'
+        filterRegExp: '^(?!timeline:).*$'
+    }
+    
+    property var placesMaybeTimeline {
+        if (showTimeline) {
+            return placesMaybeHidden
+        } else {
+            return placesNoTimeline
+        }
+    }
+    
+    PlasmaCore.SortFilterModel {
+        id: placesNoSearch
+        sourceModel: placesMaybeTimeline
+        filterRole: 'url'
+        filterRegExp: '^(?!search:).*$'
+    }
+    
+    property var placesMaybeSearch {
+        if (showSearch) {
+            return placesMaybeTimeline
+        } else {
+            return placesNoSearch
+        }
+    }
+    
+    
+    PlasmaCore.SortFilterModel {
+        id: placesNoDevice
+        sourceModel: placesMaybeSearch
+        filterRole: 'isDevice'
+        filterRegExp: 'false'
+    }
+    
+    PlasmaCore.SortFilterModel {
+        id: placesNoFstabDevice
+        sourceModel: placesMaybeSearch
+        
+        filters: [
+            AnyOf {
+                ValueFilter {
+                    roleName: 'isDevice'
+                    value: false
+                }
+                ValueFilter {
+                    roleName: 'setupNeeded'
+                    value: true
+                }
+                RegExpFilter {
+                    roleName: 'path'
+                    pattern: '^/media/.*$'
+                }
+            }
+        ]
+    }
+    
+    
+    property var placesMaybeDevice {
+        if (showDevice == 1) {
+            return placesNoDevice
+        } else if (showDevice == 2) {
+            return placesNoFstabDevice
+        } else {
+            return placesMaybeSearch
+        }
+    }
+
+    
+    property var currentModel: {
+        return placesMaybeDevice
     }
 
     PlasmaExtras.ScrollArea {

--- a/package/contents/ui/config/ConfigGeneral.qml
+++ b/package/contents/ui/config/ConfigGeneral.qml
@@ -20,7 +20,9 @@ import QtQuick.Layouts 1.1
 
 Item {
     property alias cfg_showHidden: showHidden.checked
-    property alias cfg_showDevices: showDevices.checked
+    property alias cfg_showTimeline: showTimeline.checked
+    property alias cfg_showSearch: showSearch.checked
+    property alias cfg_showDevices: showDevices.currentIndex
     property alias cfg_widgetWidth: widgetWidth.value
 
     property var mediumSpacing: 1.5*units.smallSpacing
@@ -33,11 +35,26 @@ Item {
             text: i18n('Show hidden places')
             Layout.columnSpan: 2
         }
-
+        
         CheckBox {
-            id: showDevices
-            text: i18n('Show devices')
+            id: showTimeline
+            text: i18n('Show Timeline places')
             Layout.columnSpan: 2
+        }
+        
+        CheckBox {
+            id: showSearch
+            text: i18n('Show Search places')
+            Layout.columnSpan: 2
+        }
+
+        Label {
+            text: i18n('Show devices')
+        }
+        
+        ComboBox {
+            id: showDevices
+            model: [i18n('All'), i18n('None'), i18n('Only those not present in fstab')]
         }
 
         Label {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -20,7 +20,9 @@ import org.kde.plasma.core 2.0 as PlasmaCore
 
 Item {
     property bool showHidden: plasmoid.configuration.showHidden
-    property bool showDevices: plasmoid.configuration.showDevices
+    property bool showTimeline: plasmoid.configuration.showTimeline
+    property bool showSearch: plasmoid.configuration.showSearch
+    property int showDevices: plasmoid.configuration.showDevices
     property int widgetWidth: plasmoid.configuration.widgetWidth
 
     Plasmoid.compactRepresentation: PlasmaCore.IconItem {


### PR DESCRIPTION
My first attempt at QML.
It does not work as intended, but I do not understand why.
Possible causes :

- I did not get the currentIndex right and this skews the meaning of the different options for showing devices
- I did not get the QRegExp right, but I think the ```(?!)``` idiom is conform to https://doc.qt.io/archives/qt-4.8/qregexp.html#assertions
- the data in ```url``` and ```path``` have invisible garbage at the beginning which prevents the regexp from matching. 
 